### PR TITLE
Add support for sun5i-a13

### DIFF
--- a/sun5i-a13/README.sun5i-a13-overlays
+++ b/sun5i-a13/README.sun5i-a13-overlays
@@ -22,6 +22,7 @@ I2C bus 0 is used for the AXP209 PMIC
 - spi2
 - spi-jedec-nor
 - spi-spidev
+- uart0
 - uart1
 - uart2
 - uart3

--- a/sun5i-a13/README.sun5i-a13-overlays
+++ b/sun5i-a13/README.sun5i-a13-overlays
@@ -1,0 +1,179 @@
+This document describes overlays provided in the kernel packages
+For generic Armbian overlays documentation please see
+https://docs.armbian.com/User-Guide_Allwinner_overlays/
+
+### Platform:
+
+sun5i-a13 (Allwinner A13)
+
+### Platform details:
+
+Supported pin banks: PB, PC, PD, PE, PG, PH, PI
+
+SPI controller 0 have 2 exposed hardware CS,
+other SPI controllers have only one hardware CS
+Reference: A10 User manual section 17.4.13, A10 datasheet section 5.2
+
+I2C bus 0 is used for the AXP209 PMIC
+
+### Provided overlays:
+
+- analog-codec
+- i2c1
+- i2c2
+- nand
+- pwm
+- spi0
+- spi1
+- spi2
+- spi-jedec-nor
+- spi-spidev
+- uart1
+- uart2
+- uart3
+
+### Overlay details:
+
+### analog-codec
+
+Activates SoC analog codec driver that provides Line Out and Mic In
+functionality
+
+### i2c1
+
+Activates TWI/I2C bus 1
+
+I2C1 pins (SCL, SDA): PB18, PB19
+
+### i2c2
+
+Activates TWI/I2C bus 2
+
+I2C2 pins (SCL, SDA): PB20, PB21
+
+### nand
+
+Activates NAND controller
+
+This overlay should not be used until mainline MLC NAND support
+allows using NAND storage reliably
+
+### pwm
+
+Activates hardware PWM controller
+
+PWM pins (PWM0, PWM1): PB2, PI3
+
+Parameters:
+
+param_pwm_pins (string)
+	PWM pins activated with this overlay
+	Optional
+	Default: both
+	Supported values: 0, 1, both
+	If set to 0 only PWM0 can be used,
+		if set to 1 then only PWM1 can be used,
+		if set to both (default), both PWM0 and PWM1 can be used
+
+### spi0
+
+Activates SPI controller 0 to use it with other overlays and sets up the pin multiplexing for it
+
+SPI 0 pins (MOSI, MISO, SCK, CS0, CS1): PI12, PI13, PI11, PI10, PI14
+
+### spi1
+
+Activates SPI controller 1 to use it with other overlays and sets up the pin multiplexing for it
+
+SPI 1 pins (MOSI, MISO, SCK, CS0): PI18, PI19, PI17, PI16
+
+### spi2
+
+Activates SPI controller 2 to use it with other overlays and sets up the pin multiplexing for it
+
+SPI 2 pins a (MOSI, MISO, SCK, CS0): PC21, PC22, PC20, PC19
+SPI 2 pins b (MOSI, MISO, SCK, CS0): PB16, PB17, PB15, PB14
+
+Parameters:
+
+param_spi2_bus_pins (char)
+	SPI bus 2 pinmux variant
+	Optional
+	Default: a
+	Supported values: a, b
+	Determines what pins SPI bus 2 is exposed on if SPI 2 is used
+
+
+### spi-jedec-nor
+
+Activates MTD support for JEDEC compatible SPI NOR flash chips on SPI bus
+supported by the kernel SPI NOR driver
+
+SPI 0 pins (MOSI, MISO, SCK, CS0, CS1): PI12, PI13, PI11, PI10, PI14
+SPI 1 pins (MOSI, MISO, SCK, CS0): PI18, PI19, PI17, PI16
+SPI 2 pins a (MOSI, MISO, SCK, CS0): PC21, PC22, PC20, PC19
+SPI 2 pins b (MOSI, MISO, SCK, CS0): PB16, PB17, PB15, PB14
+
+Parameters:
+
+param_spinor_spi_bus (int)
+	SPI bus to activate SPI NOR flash support on
+	Required
+	Supported values: 0, 1, 2
+
+param_spinor_max_freq (int)
+	Maximum SPI frequency
+	Optional
+	Default: 1000000
+	Range: 3000 - 100000000
+
+### spi-spidev
+
+Activates SPIdev device node (/dev/spidevX.Y) for userspace SPI access,
+where X is the bus number and Y is the CS number
+
+SPI 0 pins (MOSI, MISO, SCK, CS0, CS1): PI12, PI13, PI11, PI10, PI14
+SPI 1 pins (MOSI, MISO, SCK, CS0): PI18, PI19, PI17, PI16
+SPI 2 pins a (MOSI, MISO, SCK, CS0): PC21, PC22, PC20, PC19
+SPI 2 pins b (MOSI, MISO, SCK, CS0): PB16, PB17, PB15, PB14
+
+Parameters:
+
+param_spidev_spi_bus (int)
+	SPI bus to activate mcp2515 support on
+	Required
+	Supported values: 0, 1, 2
+
+param_spidev_max_freq (int)
+	Maximum SPIdev frequency
+	Optional
+	Default: 1000000
+	Range: 3000 - 100000000
+
+### uart2
+
+Activates serial port 2 (/dev/ttyS2)
+
+UART 2 pins (TX, RX, RTS, CTS): PI18, PI19, PI16, PI17
+
+Parameters:
+
+param_uart2_rtscts (bool)
+	Enable RTS and CTS pins
+	Optional
+	Default: 0
+	Set to 1 to enable CTS and RTS pins
+
+### uart3
+
+Activates serial port 3 (/dev/ttyS3)
+
+UART 3 pins (TX, RX, RTS, CTS): PG6, PG7, PG8, PG9
+
+Parameters:
+
+param_uart3_rtscts (bool)
+	Enable RTS and CTS pins
+	Optional
+	Default: 0
+	Set to 1 to enable CTS and RTS pins

--- a/sun5i-a13/README.sun5i-a13-overlays
+++ b/sun5i-a13/README.sun5i-a13-overlays
@@ -8,12 +8,6 @@ sun5i-a13 (Allwinner A13)
 
 ### Platform details:
 
-Supported pin banks: PB, PC, PD, PE, PG, PH, PI
-
-SPI controller 0 have 2 exposed hardware CS,
-other SPI controllers have only one hardware CS
-Reference: A10 User manual section 17.4.13, A10 datasheet section 5.2
-
 I2C bus 0 is used for the AXP209 PMIC
 
 ### Provided overlays:
@@ -36,20 +30,20 @@ I2C bus 0 is used for the AXP209 PMIC
 
 ### analog-codec
 
-Activates SoC analog codec driver that provides Line Out and Mic In
+Activates SoC analog codec driver that provides HP Out and Mic In
 functionality
 
 ### i2c1
 
 Activates TWI/I2C bus 1
 
-I2C1 pins (SCL, SDA): PB18, PB19
+I2C1 pins (SCL, SDA): PB15, PB16
 
 ### i2c2
 
 Activates TWI/I2C bus 2
 
-I2C2 pins (SCL, SDA): PB20, PB21
+I2C2 pins (SCL, SDA): PB17, PB18
 
 ### nand
 
@@ -62,57 +56,34 @@ allows using NAND storage reliably
 
 Activates hardware PWM controller
 
-PWM pins (PWM0, PWM1): PB2, PI3
-
-Parameters:
-
-param_pwm_pins (string)
-	PWM pins activated with this overlay
-	Optional
-	Default: both
-	Supported values: 0, 1, both
-	If set to 0 only PWM0 can be used,
-		if set to 1 then only PWM1 can be used,
-		if set to both (default), both PWM0 and PWM1 can be used
+PWM pins (PWM0): PB2
 
 ### spi0
 
 Activates SPI controller 0 to use it with other overlays and sets up the pin multiplexing for it
 
-SPI 0 pins (MOSI, MISO, SCK, CS0, CS1): PI12, PI13, PI11, PI10, PI14
+SPI 0 pins (MOSI, MISO, SCK, CS0): PC0, PC1, PC2, PC3
 
 ### spi1
 
 Activates SPI controller 1 to use it with other overlays and sets up the pin multiplexing for it
 
-SPI 1 pins (MOSI, MISO, SCK, CS0): PI18, PI19, PI17, PI16
+SPI 1 pins (MOSI, MISO, SCK, CS0): PG11, PG12, PG10, PG9
 
 ### spi2
 
 Activates SPI controller 2 to use it with other overlays and sets up the pin multiplexing for it
 
-SPI 2 pins a (MOSI, MISO, SCK, CS0): PC21, PC22, PC20, PC19
-SPI 2 pins b (MOSI, MISO, SCK, CS0): PB16, PB17, PB15, PB14
-
-Parameters:
-
-param_spi2_bus_pins (char)
-	SPI bus 2 pinmux variant
-	Optional
-	Default: a
-	Supported values: a, b
-	Determines what pins SPI bus 2 is exposed on if SPI 2 is used
-
+SPI 2 pins (MOSI, MISO, SCK, CS0): PE2, PE3, PE1, PE0
 
 ### spi-jedec-nor
 
 Activates MTD support for JEDEC compatible SPI NOR flash chips on SPI bus
 supported by the kernel SPI NOR driver
 
-SPI 0 pins (MOSI, MISO, SCK, CS0, CS1): PI12, PI13, PI11, PI10, PI14
-SPI 1 pins (MOSI, MISO, SCK, CS0): PI18, PI19, PI17, PI16
-SPI 2 pins a (MOSI, MISO, SCK, CS0): PC21, PC22, PC20, PC19
-SPI 2 pins b (MOSI, MISO, SCK, CS0): PB16, PB17, PB15, PB14
+SPI 0 pins (MOSI, MISO, SCK, CS0): PC0, PC1, PC2, PC3
+SPI 1 pins (MOSI, MISO, SCK, CS0): PG11, PG12, PG10, PG9
+SPI 2 pins (MOSI, MISO, SCK, CS0): PE2, PE3, PE1, PE0
 
 Parameters:
 
@@ -132,10 +103,9 @@ param_spinor_max_freq (int)
 Activates SPIdev device node (/dev/spidevX.Y) for userspace SPI access,
 where X is the bus number and Y is the CS number
 
-SPI 0 pins (MOSI, MISO, SCK, CS0, CS1): PI12, PI13, PI11, PI10, PI14
-SPI 1 pins (MOSI, MISO, SCK, CS0): PI18, PI19, PI17, PI16
-SPI 2 pins a (MOSI, MISO, SCK, CS0): PC21, PC22, PC20, PC19
-SPI 2 pins b (MOSI, MISO, SCK, CS0): PB16, PB17, PB15, PB14
+SPI 0 pins (MOSI, MISO, SCK, CS0): PC0, PC1, PC2, PC3
+SPI 1 pins (MOSI, MISO, SCK, CS0): PG11, PG12, PG10, PG9
+SPI 2 pins (MOSI, MISO, SCK, CS0): PE2, PE3, PE1, PE0
 
 Parameters:
 
@@ -150,11 +120,33 @@ param_spidev_max_freq (int)
 	Default: 1000000
 	Range: 3000 - 100000000
 
+### uart 0
+
+Activates serial port 0 (/dev/ttyS0)
+
+UART 0 pins (TX, RX): PF2, PF4
+
+### uart 1
+
+Activates serial port 1 (/dev/ttyS1)
+
+UART 1 pins a (TX, RX): PE10, PE11
+UART 1 pins b (TX, RX): PG3, PG4
+
+Parameters:
+
+param_uart1_pins (char)
+	UART 1 pinmux variant
+	Optional
+	Default: a
+	Supported values: a, b
+	Determines what pins UART 1 is exposed on if UART 1 is used
+
 ### uart2
 
 Activates serial port 2 (/dev/ttyS2)
 
-UART 2 pins (TX, RX, RTS, CTS): PI18, PI19, PI16, PI17
+UART 2 pins (TX, RX, RTS, CTS): PD2, PD3, PD4, PD5
 
 Parameters:
 
@@ -168,7 +160,7 @@ param_uart2_rtscts (bool)
 
 Activates serial port 3 (/dev/ttyS3)
 
-UART 3 pins (TX, RX, RTS, CTS): PG6, PG7, PG8, PG9
+UART 3 pins (TX, RX, RTS, CTS): PG9, PG10, PG12, PG11
 
 Parameters:
 

--- a/sun5i-a13/sun5i-a13-analog-codec.dts
+++ b/sun5i-a13/sun5i-a13-analog-codec.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun4i-a13";
+
+	fragment@0 {
+		target = <&codec>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/sun5i-a13/sun5i-a13-fixup.scr-cmd
+++ b/sun5i-a13/sun5i-a13-fixup.scr-cmd
@@ -1,0 +1,42 @@
+# overlays fixup script
+# implements (or rather substitutes) overlay arguments functionality
+# using u-boot scripting, environment variables and "fdt" command
+
+if test -n "${param_spinor_spi_bus}"; then
+	test "${param_spinor_spi_bus}" = "0" && setenv tmp_spi_path "spi@01c05000"
+	test "${param_spinor_spi_bus}" = "1" && setenv tmp_spi_path "spi@01c06000"
+	test "${param_spinor_spi_bus}" = "2" && setenv tmp_spi_path "spi@01c17000"
+	fdt set /soc@01c00000/${tmp_spi_path} status "okay"
+	fdt set /soc@01c00000/${tmp_spi_path}/spiflash status "okay"
+	if test -n "${param_spinor_max_freq}"; then
+		fdt set /soc@01c00000/${tmp_spi_path}/spiflash spi-max-frequency "<${param_spinor_max_freq}>"
+	fi
+	env delete tmp_spi_path
+fi
+
+if test -n "${param_spidev_spi_bus}"; then
+	test "${param_spidev_spi_bus}" = "0" && setenv tmp_spi_path "spi@01c05000"
+	test "${param_spidev_spi_bus}" = "1" && setenv tmp_spi_path "spi@01c06000"
+	test "${param_spidev_spi_bus}" = "2" && setenv tmp_spi_path "spi@01c17000"
+	fdt set /soc@01c00000/${tmp_spi_path} status "okay"
+	fdt set /soc@01c00000/${tmp_spi_path}/spidev status "okay"
+	if test -n "${param_spidev_max_freq}"; then
+		fdt set /soc@01c00000/${tmp_spi_path}/spidev spi-max-frequency "<${param_spidev_max_freq}>"
+	fi
+	env delete tmp_spi_path
+fi
+
+if test "${param_uart2_rtscts}" = "1"; then
+	fdt get value tmp_phandle1 /soc@01c00000/pinctrl@01c20800/uart2@0 phandle
+	fdt get value tmp_phandle2 /soc@01c00000/pinctrl@01c20800/uart2-cts-rts@0 phandle
+	fdt set /soc@01c00000/serial@01c28800 pinctrl-0 "<${tmp_phandle1}>, <${tmp_phandle2}>"
+	env delete tmp_phandle1 tmp_phandle2
+fi
+
+if test "${param_uart3_rtscts}" = "1"; then
+	fdt get value tmp_phandle1 /soc@01c00000/pinctrl@01c20800/uart3@0 phandle
+	fdt get value tmp_phandle2 /soc@01c00000/pinctrl@01c20800/uart3-cts-rts@0 phandle
+	fdt set /soc@01c00000/serial@01c28c00 pinctrl-names "default" "default"
+	fdt set /soc@01c00000/serial@01c28c00 pinctrl-0 "<${tmp_phandle1}>, <${tmp_phandle2}>"
+	env delete tmp_phandle1 tmp_phandle2
+fi

--- a/sun5i-a13/sun5i-a13-fixup.scr-cmd
+++ b/sun5i-a13/sun5i-a13-fixup.scr-cmd
@@ -26,6 +26,12 @@ if test -n "${param_spidev_spi_bus}"; then
 	env delete tmp_spi_path
 fi
 
+if test "${param_uart1_pins}" = "b"; then
+	fdt get value tmp_phandle /soc@01c00000/pinctrl@01c28400/uart1@1 phandle
+	fdt set /soc@01c00000/serial@01c28400 pinctrl-0 "<${tmp_phandle}>"
+	env delete tmp_phandle
+fi
+
 if test "${param_uart2_rtscts}" = "1"; then
 	fdt get value tmp_phandle1 /soc@01c00000/pinctrl@01c20800/uart2@0 phandle
 	fdt get value tmp_phandle2 /soc@01c00000/pinctrl@01c20800/uart2-cts-rts@0 phandle

--- a/sun5i-a13/sun5i-a13-i2c1.dts
+++ b/sun5i-a13/sun5i-a13-i2c1.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			i2c1 = "/soc@01c00000/i2c@01c2b000";
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c1_pins_a>;
+			status = "okay";
+		};
+	};
+};

--- a/sun5i-a13/sun5i-a13-i2c2.dts
+++ b/sun5i-a13/sun5i-a13-i2c2.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			i2c2 = "/soc@01c00000/i2c@01c2b400";
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c2>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c2_pins_a>;
+			status = "okay";
+		};
+	};
+};

--- a/sun5i-a13/sun5i-a13-nand.dts
+++ b/sun5i-a13/sun5i-a13-nand.dts
@@ -1,0 +1,60 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target = <&nfc>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&nand_pins_a>, <&nand_cs0_pins_a>, <&nand_rb0_pins_a>;
+			status = "okay";
+
+			nand@0 {
+				reg = <0>;
+				allwinner,rb = <0>;
+				nand-ecc-mode = "hw";
+				nand-on-flash-bbt;
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <2>;
+					#size-cells = <2>;
+
+					partition@0 {
+						label = "SPL";
+						reg = <0x0 0x0 0x0 0x400000>;
+					};
+
+					partition@400000 {
+						label = "SPL.backup";
+						reg = <0x0 0x400000 0x0 0x400000>;
+					};
+
+					partition@800000 {
+						label = "U-Boot";
+						reg = <0x0 0x800000 0x0 0x400000>;
+					};
+
+					partition@c00000 {
+						label = "U-Boot.backup";
+						reg = <0x0 0xc00000 0x0 0x400000>;
+					};
+
+					partition@1000000 {
+						label = "env";
+						reg = <0x0 0x1000000 0x0 0x400000>;
+					};
+
+					partition@1400000 {
+						label = "rootfs";
+						reg = <0x0 0xa00000 0x01 0xff000000>;
+					};
+				};
+			};
+		};
+	};
+};

--- a/sun5i-a13/sun5i-a13-pwm.dts
+++ b/sun5i-a13/sun5i-a13-pwm.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target = <&pwm>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&pwm0_pins>;
+			status = "okay";
+		};
+	};
+};

--- a/sun5i-a13/sun5i-a13-spi-jedec-nor.dts
+++ b/sun5i-a13/sun5i-a13-spi-jedec-nor.dts
@@ -1,0 +1,57 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			spi0 = "/soc/spi@01c05000";
+			spi1 = "/soc/spi@01c06000";
+			spi2 = "/soc/spi@01c17000";
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			spiflash {
+				compatible = "jedec,spi-nor";
+				status = "disabled";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			spiflash {
+				compatible = "jedec,spi-nor";
+				status = "disabled";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi2>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			spiflash {
+				compatible = "jedec,spi-nor";
+				status = "disabled";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+};

--- a/sun5i-a13/sun5i-a13-spi-spidev.dts
+++ b/sun5i-a13/sun5i-a13-spi-spidev.dts
@@ -1,0 +1,57 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a10";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			spi0 = "/soc/spi@01c05000";
+			spi1 = "/soc/spi@01c06000";
+			spi2 = "/soc/spi@01c17000";
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			spidev {
+				compatible = "spidev";
+				status = "disabled";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			spidev {
+				compatible = "spidev";
+				status = "disabled";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi2>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			spidev {
+				compatible = "spidev";
+				status = "disabled";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+};

--- a/sun5i-a13/sun5i-a13-spi0.dts
+++ b/sun5i-a13/sun5i-a13-spi0.dts
@@ -12,16 +12,6 @@
 	};
 
 	fragment@1 {
-		target = <&spi0>;
-		__overlay__ {
-			status = "okay";
-			pinctrl-names = "default", "default";
-			pinctrl-0 = <&spi0_pins_a>;
-			pinctrl-1 = <&spi0_cs0_pins_a>;
-		};
-	};
-
-	fragment@2 {
 		target = <&pio>;
 		__overlay__ {
 			spi0_pins_a: spi0@0 {
@@ -34,5 +24,15 @@
 				function = "spi0";
 			};
 		};
-	}
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+				status = "okay";
+				pinctrl-names = "default", "default";
+				pinctrl-0 = <&spi0_pins_a>;
+				pinctrl-1 = <&spi0_cs0_pins_a>;
+		};
+	};
 };

--- a/sun5i-a13/sun5i-a13-spi0.dts
+++ b/sun5i-a13/sun5i-a13-spi0.dts
@@ -1,0 +1,38 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			spi0 = "/soc/spi@01c05000";
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default", "default";
+			pinctrl-0 = <&spi0_pins_a>;
+			pinctrl-1 = <&spi0_cs0_pins_a>;
+		};
+	};
+
+	fragment@2 {
+		target = <&pio>;
+		__overlay__ {
+			spi0_pins_a: spi0@0 {
+				pins = "PC0", "PC1", "PC2";
+				function = "spi0";
+			};
+
+			spi0_cs0_pins_a: spi0-cs0@0 {
+				pins = "PC3";
+				function = "spi0";
+			};
+		};
+	}
+};

--- a/sun5i-a13/sun5i-a13-spi1.dts
+++ b/sun5i-a13/sun5i-a13-spi1.dts
@@ -12,15 +12,6 @@
 	};
 
 	fragment@1 {
-		target = <&spi1>;
-		__overlay__ {
-			status = "okay";
-			pinctrl-names = "default";
-			pinctrl-0 = <&spi1_pins_a>, <&spi1_cs0_pins_a>;
-		};
-	};
-
-	fragment@2 {
 		target = <&pio>;
 		__overlay__ {
 			spi1_pins_a: spi1@0 {
@@ -32,6 +23,17 @@
 				pins = "PG9";
 				function = "spi1";
 			};
-		}
+		};
 	};
+
+	fragment@2 {
+		target = <&spi1>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi1_pins_a>, <&spi1_cs0_pins_a>;
+		};
+	};
+
+
 };

--- a/sun5i-a13/sun5i-a13-spi1.dts
+++ b/sun5i-a13/sun5i-a13-spi1.dts
@@ -1,0 +1,37 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			spi1 = "/soc/spi@01c06000";
+		};
+	};
+
+	fragment@1 {
+		target = <&spi1>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi1_pins_a>, <&spi1_cs0_pins_a>;
+		};
+	};
+
+	fragment@2 {
+		target = <&pio>;
+		__overlay__ {
+			spi1_pins_a: spi1@0 {
+				pins = "PG10", "PG11", "PG12";
+				function = "spi1";
+			};
+
+			spi1_cs0_pins_a: spi1-cs0@0 {
+				pins = "PG9";
+				function = "spi1";
+			};
+		}
+	};
+};

--- a/sun5i-a13/sun5i-a13-spi2.dts
+++ b/sun5i-a13/sun5i-a13-spi2.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			spi2 = "/soc/spi@01c17000";
+		};
+	};
+
+	fragment@1 {
+		target = <&spi2>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi2_pins_a>, <&spi2_cs0_pins_a>;
+		};
+	};
+};

--- a/sun5i-a13/sun5i-a13-uart0.dts
+++ b/sun5i-a13/sun5i-a13-uart0.dts
@@ -1,0 +1,32 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			uart0 = "/soc@01c00000/serial@01c28000";
+		};
+	};
+
+	fragment@1 {
+		target = <&pio>;
+		__overlay__ {
+			uart0_pins_a: uart0@0 {
+				pins = "PF2", "PF4";
+				function = "uart0";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&uart0>;
+		 __overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&uart0_pins_a>;
+			status = "okay";
+		};
+	};
+};

--- a/sun5i-a13/sun5i-a13-uart1.dts
+++ b/sun5i-a13/sun5i-a13-uart1.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			uart1 = "/soc@01c00000/serial@01c28400";
+		};
+	};
+
+	fragment@1 {
+		target = <&uart1>;
+		 __overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&uart1_pins_a>;
+			status = "okay";
+		};
+	};
+};

--- a/sun5i-a13/sun5i-a13-uart2.dts
+++ b/sun5i-a13/sun5i-a13-uart2.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			uart2 = "/soc@01c00000/serial@01c28800";
+		};
+	};
+
+	fragment@1 {
+		target = <&uart2>;
+		 __overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&uart2_pins_a>;
+			status = "okay";
+		};
+	};
+};

--- a/sun5i-a13/sun5i-a13-uart3.dts
+++ b/sun5i-a13/sun5i-a13-uart3.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun5i-a13";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			uart3 = "/soc@01c00000/serial@01c28c00";
+		};
+	};
+
+	fragment@1 {
+		target = <&uart3>;
+		 __overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&uart3_pins_a>;
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
Add overlays for sun5i-a13 platform. The provided overlays are:

- analog-codec
- i2c1
- i2c2
- nand
- pwm
- spi0
- spi1
- spi2
- spi-jedec-nor
- spi-spidev
- uart0
- uart1
- uart2
- uart3

Almost all are tested (except uart2 and uart3, because conflicts with other peripheries).