### PR TITLE
Added gpio-poweroff driver overlay for sun8i-h3

### DIFF
--- a/sun8i-h3/README.sun8i-h3-overlays
+++ b/sun8i-h3/README.sun8i-h3-overlays
@@ -17,6 +17,7 @@ adding fixed software (GPIO) chip selects is possible with a separate overlay
 
 - analog-codec
 - cir
+- gpio-poweroff
 - i2c0
 - i2c1
 - i2c2
@@ -67,6 +68,16 @@ Activates TWI/I2C bus 2
 I2C2 pins (SCL, SDA): PE12, PE13
 
 On most board this bus is wired to Camera (CSI) socket
+
+### gpio-poweroff
+
+Activates poweroff gpio driver, this driver toggles a pin when the system shuts down
+
+Parameters:
+
+param_pwr_off_pin (pin)
+	Pin which outputs poweroff signal when system halts
+	Default: PG11
 
 ### pps-gpio
 

--- a/sun8i-h3/sun8i-h3-gpio-poweroff.dts
+++ b/sun8i-h3/sun8i-h3-gpio-poweroff.dts
@@ -20,7 +20,7 @@
 			gpio-poweroff {
 				compatible = "gpio-poweroff";
 				pinctrl-names = "default";
-                                pinctrl-0 = <&pwr_off_pins>;
+				pinctrl-0 = <&pwr_off_pins>;
 				gpios = <&pio 6 11 0>;
 			};
 		};

--- a/sun8i-h3/sun8i-h3-gpio-poweroff.dts
+++ b/sun8i-h3/sun8i-h3-gpio-poweroff.dts
@@ -1,0 +1,28 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun8i-h3";
+
+	fragment@0 {
+		target = <&pio>;
+		__overlay__ {
+			pwr_off_pins: pwr_off_pins {
+				pins = "PG11";
+				function = "gpio_out";
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			gpio-poweroff {
+				compatible = "gpio-poweroff";
+				pinctrl-names = "default";
+                                pinctrl-0 = <&pwr_off_pins>;
+				gpios = <&pio 6 11 0>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
This is meant to support true power off by power switch for battery powered applications. The gpio-poweroff driver will toggle a pin if the system is halted. An external micro can then turn off the power to the processor.