### PR TITLE
nand: correct rootfs start offset

### DIFF
--- a/sun4i-a10/sun4i-a10-nand.dts
+++ b/sun4i-a10/sun4i-a10-nand.dts
@@ -94,7 +94,7 @@
 
 					partition@1400000 {
 						label = "rootfs";
-						reg = <0x0 0xa00000 0x01 0xff000000>;
+						reg = <0x0 0x1400000 0x01 0xff000000>;
 					};
 				};
 			};

--- a/sun5i-a13/sun5i-a13-nand.dts
+++ b/sun5i-a13/sun5i-a13-nand.dts
@@ -51,7 +51,7 @@
 
 					partition@1400000 {
 						label = "rootfs";
-						reg = <0x0 0xa00000 0x01 0xff000000>;
+						reg = <0x0 0x1400000 0x01 0xff000000>;
 					};
 				};
 			};

--- a/sun7i-a20/sun7i-a20-nand.dts
+++ b/sun7i-a20/sun7i-a20-nand.dts
@@ -94,7 +94,7 @@
 
 					partition@1400000 {
 						label = "rootfs";
-						reg = <0x0 0xa00000 0x01 0xff000000>;
+						reg = <0x0 0x1400000 0x01 0xff000000>;
 					};
 				};
 			};


### PR DESCRIPTION
It seems to me that rootfs offset is wrong. This explains to me ubi corruption which I encountered while testing it on cubieboard and cubieboard2.

Other than this, overlays work for me on cubieboard and cubieboard2 so thanks for them. I still have trouble getting partitions in u-boot, but that's topic for patch in different repo :-)