### PR TITLE
can pin correct

### DIFF
--- a/sun7i-a20/sun7i-a20-can.dts
+++ b/sun7i-a20/sun7i-a20-can.dts
@@ -1,15 +1,20 @@
 /dts-v1/;
-/plugin/;
 
 / {
 	compatible = "allwinner,sun7i-a20";
 
 	fragment@0 {
-		target = <&can0>;
+		target = < 0xffffffff >;
+
 		__overlay__ {
 			pinctrl-names = "default";
-			pinctrl-0 = <&can0_pins_a>;
+			pinctrl-0 = < 0xffffffff >;
 			status = "okay";
 		};
+	};
+
+	__fixups__ {
+		can0 = "/fragment@0:target:0";
+		can_ph_pins = "/fragment@0/__overlay__:pinctrl-0:0";
 	};
 };


### PR DESCRIPTION
"can0_pins_a" is not correct, correct "can_ph_pins" or "can_pa_pins" 
because all files "sun7i-a20-*.dts" files  has definition:
			can-pa-pins {
				pins = "PA16\0PA17";
				function = "can";
				phandle = < 0x63 >;
			};
			can-ph-pins {
				pins = "PH20\0PH21";
				function = "can";
				phandle = < 0x64 >;
			}; 

and 
		can_pa_pins = "/soc/pinctrl@1c20800/can-pa-pins";
		can_ph_pins = "/soc/pinctrl@1c20800/can-ph-pins";