### PR TITLE
Sun50i h6 pwm

### DIFF
--- a/sun50i-h6/README.sun50i-h6-overlays
+++ b/sun50i-h6/README.sun50i-h6-overlays
@@ -1,0 +1,27 @@
+This document describes overlays provided in the kernel packages
+For generic Armbian overlays documentation please see
+https://docs.armbian.com/User-Guide_Allwinner_overlays/
+
+### Platform:
+
+sun50i-h6 (Allwinner H6)
+
+### Platform details:
+
+Please refer to h5 documentation for all missing.
+
+
+### Provided overlays:
+
+- pwm
+
+### Overlay details:
+
+### pwm
+
+Activates hardware PWM controller
+
+PWM pin: PD22
+
+Attention: On some board as "OrangePi Lite 2" there is an exposed pin marked as PWM1.
+           This is NOT the PWM1 pin. As datasheet the only PWM pin available is PD22 (ALT2).

--- a/sun50i-h6/sun50i-h6-pwm.dts
+++ b/sun50i-h6/sun50i-h6-pwm.dts
@@ -1,0 +1,28 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "allwinner,sun50i-h6-pwm";
+
+
+        fragment@0 {
+                target = <&pio>;
+                __overlay__ {
+                        pwm0_pin: pwm0_pin {
+                                pins = "PD22";
+                                function = "pwm";
+                        };
+                };
+        };
+
+
+        fragment@1 {
+                target = <&pwm>;
+                __overlay__ {
+                        pinctrl-names = "default";
+                        pinctrl-0 = <&pwm0_pin>;
+                        status = "okay";
+                };
+        };
+
+};


### PR DESCRIPTION
This little patch add the pwm controller and the pin to h6 platform.

Tested on a OrangePi Lite 2.